### PR TITLE
Add Makefile wrappers around magefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+GO = go
+MAGE = $(GO) run github.com/magefile/mage
+
+TARGETS := $(shell $(MAGE) -l | awk '\
+	BEGIN { count = 1 }\
+	/^  / { gsub(/:/, ".", $$1); if (sub(/\*$$/, "", $$1) > 0) { targets[0] = $$1 } else { targets[count++] = $$1 } }\
+	END   { for (i = 0; i < count; i++) { print targets[i] } }\
+')
+
+.PHONY: $(TARGETS)
+
+$(TARGETS):
+	@$(MAGE) $(subst .,:,$@)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,0 +1,1 @@
+../Makefile


### PR DESCRIPTION
Here is a proposal to automatically expose `mage` targets as `make` targets:
- `make` becomes equivalent to `go run mage.go` (default target preserved)
- `make foo.bar` becomes equivalent to `go run mage.go foo:bar` (colon replaced with dot)
- `make <tab><tab>` allows to discover targets through autocompletion (but slow)

Feel free to ignore this if it looks overkill to you :wink: 